### PR TITLE
admin notice 수정

### DIFF
--- a/team2_Project/src/com/kh/notice/model/service/AdminNoticeService.java
+++ b/team2_Project/src/com/kh/notice/model/service/AdminNoticeService.java
@@ -122,9 +122,8 @@ public class AdminNoticeService { // class start
 		Connection conn = getConnection();
 		
 		int result1 = new AdminNoticeDao().deleteNotice(conn, deleteList);
-		int result2 = new AdminNoticeDao().deleteAttachment(conn, deleteList);
 		
-		if(result1 > 0 && result2 > 0) {
+		if(result1 > 0) {
 			commit(conn);
 		}else {
 			rollback(conn);
@@ -132,7 +131,8 @@ public class AdminNoticeService { // class start
 		
 		close(conn);
 		
-		return result1 * result2;
+		return result1;
+		
 	}
 
 


### PR DESCRIPTION
## 수정내용
> admin notice에서 첨부파일이 없을 때 공지사항을 삭제하면 정상적으로 삭제했음에도 실패라고 나오는 에러 수정

## 해결방법
> 트리거를 사용하여 공지사항의 DEL_YN 컬럼이 'Y'로 변경되면 첨부파일의 DEL_YN 컬럼도 'Y'로 변경되도록 수정
